### PR TITLE
Fix integration tests not running

### DIFF
--- a/init-and-run-tests.sh
+++ b/init-and-run-tests.sh
@@ -16,7 +16,7 @@ if [ -z "$3" ]
 then
   INTEGRATION_TEST_PATH=""
 else
-  INTEGRATION_TEST_PATH="-gdir=$3"
+  INTEGRATION_TEST_PATH=",$3"
 fi
 
 # Download Godot
@@ -36,4 +36,4 @@ then
   cd test-project
 fi
 
-/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=$UNIT_TEST_PATH $INTEGRATION_TEST_PATH
+/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=${UNIT_TEST_PATH}${INTEGRATION_TEST_PATH}

--- a/init-and-run-tests.sh
+++ b/init-and-run-tests.sh
@@ -36,4 +36,4 @@ then
   cd test-project
 fi
 
-/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=${UNIT_TEST_PATH}${INTEGRATION_TEST_PATH}
+/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=${UNIT_TEST_PATH}${INTEGRATION_TEST_PATH} -ginclude_subdirs

--- a/init-and-run-tests.sh
+++ b/init-and-run-tests.sh
@@ -36,4 +36,4 @@ then
   cd test-project
 fi
 
-/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=${UNIT_TEST_PATH}${INTEGRATION_TEST_PATH} -ginclude_subdirs
+/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=${UNIT_TEST_PATH}${INTEGRATION_TEST_PATH}

--- a/init-and-run-tests.sh
+++ b/init-and-run-tests.sh
@@ -36,4 +36,4 @@ then
   cd test-project
 fi
 
-/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=${UNIT_TEST_PATH}${INTEGRATION_TEST_PATH}
+/usr/local/bin/godot -d -s --path $PWD addons/gut/gut_cmdln.gd -gexit -gdir=$UNIT_TEST_PATH$INTEGRATION_TEST_PATH


### PR DESCRIPTION
Hi! 

Just tried using this github action and it seems to work great! Except it doesn't run integration tests, as mentioned in one of the open issues. 

I did a bit of debugging and found  the doc for `-gdir` param: https://github.com/bitwes/Gut/blob/master/addons/gut/gut_cmdln.gd#L134 seems to indicate we need to use commas to add multiple directories.

Seems to include integration tests properly after this change.

Fixes [ceceppa/godot-gut-ci#4]

Also, it looks like adding the `-ginclude_subdirs` would address [ceceppa/godot-gut-ci#3]). I personally prefer this behavior, but maybe it's best if this were specified via an additional option in the webhook (which is why I didn't include it in this pull request)?