### PR TITLE
Extended condition to check if no tests were actually run, so it also works with the current GUT version.

### DIFF
--- a/init-and-run-tests.sh
+++ b/init-and-run-tests.sh
@@ -42,7 +42,7 @@ TEMP_FILE=/tmp/gut.log
 $GODOT_BIN -d -s $GODOT_PARAMS --path $PWD addons/gut/gut_cmdln.gd -gexit $GUT_PARAMS 2>&1 | tee $TEMP_FILE
 
 # Godot always exists with error 0, but we want this action to fail in case of errors
-if grep -q "No tests ran" "$TEMP_FILE";
+if grep -q "No tests ran" "$TEMP_FILE" || grep -qE "Asserts\s+none" "$TEMP_FILE";
 then
   echo "No test ran. Please check your 'gut_params'"
   exit 1


### PR DESCRIPTION
Apparently, the most-recent GUT version does not output `No tests ran` anymore. This lead me to fooling myself a bit thinking the CI was green when it actually never ran any tests, example: https://github.com/ArSn/godot-dodge-the-creeps-2d/actions/runs/8766924316/job/24059609711

I've therefore extended the condition to catch such cases. 

Example run with failing the build: https://github.com/ArSn/godot-dodge-the-creeps-2d/actions/runs/8767132951/job/24060047985
Example run with it working again because I fixed my config: https://github.com/ArSn/godot-dodge-the-creeps-2d/actions/runs/8767142140/job/24060065829